### PR TITLE
Added console rendering

### DIFF
--- a/Hahnium.Chip8/Chip8Cpu.cs
+++ b/Hahnium.Chip8/Chip8Cpu.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Buffers;
-using System.Data;
 
 namespace Hahnium.Chip8
 {
@@ -8,12 +7,12 @@ namespace Hahnium.Chip8
     {
         private const ushort OperandsMask = 0x0fff;
         private Memory<byte> ram;
-        private MemoryHandle memoryhandle;
-        byte[] registers = new byte[0x10];
-        ushort address;
-        ushort pc = 0x200;
-        ushort[] stack = new ushort[48];
-        byte sp = 0;
+        public MemoryHandle memoryhandle;
+        public byte[] Registers = new byte[0x10];
+        public ushort pc = 0x200;
+        public ushort address;
+        public ushort[] stack = new ushort[48];
+        public byte sp = 0;
 
         public Chip8Cpu(Memory<byte> ram)
         {
@@ -21,7 +20,7 @@ namespace Hahnium.Chip8
             this.memoryhandle = ram.Pin();
         }
 
-        public unsafe void Tick()
+        public unsafe void Cycle()
         {
             byte* memory = (byte*)memoryhandle.Pointer;
             ushort opcode = (ushort)((*(memory + pc++) << 8) | *(memory + pc++));

--- a/Hahnium.Chip8/Chip8Platform.cs
+++ b/Hahnium.Chip8/Chip8Platform.cs
@@ -15,12 +15,13 @@ namespace Hahnium.Chip8
             romImage.CopyTo(this.ram.Slice(0x200));
             this.cpu = new Chip8Cpu(this.ram);
             this.apu = new Chip8Apu(this.ram);
-            this.ppu = new Chip8Ppu(this.ram);
+            this.ppu = new Chip8Ppu(this.cpu, this.ram);
         }
 
-        public void Tick()
+        public void Cycle()
         {
-            this.cpu.Tick();
+            this.cpu.Cycle();
+            this.ppu.Cycle();
         }
     }
 }

--- a/Hahnium.Chip8/Program.cs
+++ b/Hahnium.Chip8/Program.cs
@@ -12,7 +12,7 @@ namespace Hahnium.Chip8
 
             while (true)
             {
-                platform.Tick();
+                platform.Cycle();
             }
         }
 


### PR DESCRIPTION
Added a basic console rendering layer with debugging info. Console characters are approximately twice as tall as they are wide, so by using the half-block characters two rows of pixels can be rendered for each single row of console characters.

This isn't optimized at all, but fuck it.

Closes #4